### PR TITLE
⚡️ greatly improve loading performance for large questionnaires

### DIFF
--- a/src/models/question.ts
+++ b/src/models/question.ts
@@ -5,6 +5,8 @@ export class NUMQuestionnaireQuestion {
   readonly parent: fhir4.Questionnaire | fhir4.QuestionnaireItem;
   readonly level: number;
 
+  #isAnsweredCache?: boolean = null;
+
   linkId: string;
   type: fhir4.QuestionnaireItem['type'];
 
@@ -144,13 +146,23 @@ export class NUMQuestionnaireQuestion {
     return this.config.itemControl === 'drop-down';
   }
 
+  resetIsAnsweredCache() {
+    this.#isAnsweredCache = null;
+  }
+
   get isAnswered() {
     if (this.type === 'group') {
       return this.children.filter(({ isEnabled }) => isEnabled).every(({ isAnswered }) => isAnswered);
     }
 
+    if (typeof this.#isAnsweredCache === 'boolean') {
+      return this.#isAnsweredCache;
+    }
+
     const { previous } = this;
-    return (!previous || previous.isAnswered) && !!this.answer;
+    const isAnswered = (!previous || previous.isAnswered) && !!this.answer;
+    this.#isAnsweredCache = isAnswered;
+    return isAnswered;
   }
 
   get isAnswerable() {

--- a/src/stores/questionnaire.ts
+++ b/src/stores/questionnaire.ts
@@ -38,9 +38,10 @@ const storeBuilder = ({ optionalPersistor }: Services) => {
 
   class Actions {
     constructor() {
-      answersStore.on('set', () =>
-        this.isPristine ? optionalPersistence.removeLeaveGuard() : optionalPersistence.addLeaveGuard()
-      );
+      answersStore.on('set', () => {
+        this.isPristine ? optionalPersistence.removeLeaveGuard() : optionalPersistence.addLeaveGuard();
+        this.resetIsAnsweredCache();
+      });
       answersStore.on('reset', () => optionalPersistence.removeLeaveGuard());
     }
 
@@ -48,6 +49,10 @@ const storeBuilder = ({ optionalPersistor }: Services) => {
       answersStore.reset();
       persistedMetaStore.reset();
       store.reset();
+    }
+
+    resetIsAnsweredCache() {
+      this.flattenedItems?.forEach((item) => item.resetIsAnsweredCache());
     }
 
     populateFromRequestResponse(response: NUMQuestionnaire) {


### PR DESCRIPTION
By adding a small caching layer to `isAnswered()` and thus drastically decreasing the recursion happening while rendering the questionnaire tree and determining the active question when opening the questionnaire, loading times for bigger questionnaires are greatly reduced. In case of the GECCO questionnaire from the implementation guide, this would result in a loading time decrease of more than 99%.