### PR TITLE
🐛 fix questionnaire guard so that it allows displaying success view

### DIFF
--- a/src/components/questionnaire/questionnaire.tsx
+++ b/src/components/questionnaire/questionnaire.tsx
@@ -30,7 +30,7 @@ export class QuestionnaireComponent {
   }
 
   render() {
-    if (!stores.user.isQuestionnaireAvailable) {
+    if (!stores.user.isQuestionnaireAvailable && this.displayMode !== 'success') {
       return <stencil-router-redirect url={ROUTES.DASHBOARD} />;
     }
 

--- a/src/components/report/report.tsx
+++ b/src/components/report/report.tsx
@@ -28,7 +28,7 @@ export class ReportComponent {
   render() {
     const { display } = this;
 
-    if (stores.user.isQuestionnaireAvailable) {
+    if (stores.user.isQuestionnaireAvailable && display !== 'success') {
       return <stencil-router-redirect url={ROUTES.DASHBOARD} />;
     }
 


### PR DESCRIPTION
The success view after answering the questionnaire was never displayed because the questionnaire guard redirected back to the dashboard after refreshing the user information and receiving the information that there is no questionnaire available (anymore).